### PR TITLE
fix: fixed the example code inside the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn add @noahsaso/cosmodal
 const MyApp: FunctionComponent<AppProps> = ({ Component, pageProps }) => (
   <WalletManagerProvider
     defaultChainId={ChainInfoID.Juno1}
-    enabledWallets={[WalletType.Keplr, WalletType.WalletConnectKeplr]}
+    enabledWalletTypes={[WalletType.Keplr, WalletType.WalletConnectKeplr]}
     walletConnectClientMeta={{
       name: "CosmodalExampleDAPP",
       description: "A dapp using the cosmodal library.",


### PR DESCRIPTION
To prevent a frustration at the start of implementation, I replaced the property `enabledWallets` with the propper one `enabledWalletTypes`. I got the impression, that this could be a preventable roadblock for every beginner trying to implement the WalletManagerProvider for the first time.